### PR TITLE
Disambiguates V2's fork from the upstream fork.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,3 @@
-# FreeImage.Standard
+# V2.FreeImage.Standard
 
-This a .NET Standard 2.0 wrapper for the FreeImage library.
-
-Currently API-compatible with the FreeImage .NET Wrapper (http://freeimage.sourceforge.net/), however this may diverge over time as the original wrapper is no longer maintained.
-
-## Installing
-Nuget package: https://www.nuget.org/packages/FreeImage.Standard
-
-`Install-Package FreeImage.Standard`
-
-![](https://img.shields.io/nuget/dt/FreeImage.Standard.svg)
-
-## Native Compatibility
-
-FreeImage native binaries are included in the nuget package for Windows x86/x64 and Linux x64/armhf.
-
-For other platforms they will have to be installed separately. Note that the native function calls require the library filename to be `FreeImage`, so symlinking may be required (eg. `sudo ln -s /usr/lib/x86_64-linux-gnu/libfreeimage.so /usr/lib/FreeImage`).
-
-## FreeImage Version
-
-This is for FreeImage version 3.18.0
-
-Note that FreeImage 3.18.0 is not available on Raspian yet - please use the v4.3.7 package which is linked against FreeImage 3.17.0 for now.
-
-**The version number of this package no longer matches the FreeImage native library version!**
-
-## License
-
-The license is the same as the FreeImage license available at the link above
+This is a fork of the FreeImage.Standard libary found here (https://github.com/LordBenjamin/FreeImage.Standard).

--- a/src/FreeImage.Standard/FreeImage.Standard.csproj
+++ b/src/FreeImage.Standard/FreeImage.Standard.csproj
@@ -3,19 +3,19 @@
   <PropertyGroup>
     <Copyright></Copyright>
     <AssemblyTitle>FreeImage.Standard</AssemblyTitle>
-    <Version>4.3.8</Version>
-    <AssemblyVersion>4.3.8.0</AssemblyVersion>
-    <FileVersion>4.3.8.0</FileVersion>
+    <Version>4.3.8.1</Version>
+    <AssemblyVersion>4.3.8.1</AssemblyVersion>
+    <FileVersion>4.3.8.1</FileVersion>
     <Authors>FreeImage contributors; matgr1; lordbenjamin</Authors>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>FreeImage.Standard</AssemblyName>
-    <PackageId>FreeImage.Standard</PackageId>
+    <PackageId>V2.FreeImage.Standard</PackageId>
     <PackageTags>FreeImage;netcore;dotnetcore</PackageTags>
     <PackageIconUrl>http://freeimage.sourceforge.net/images/logo.jpg</PackageIconUrl>
-    <PackageProjectUrl>https://github.com/LordBenjamin/FreeImage.Standard</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/velocitysquared/FreeImage.Standard</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/LordBenjamin/FreeImage.Standard</RepositoryUrl>
+    <RepositoryUrl>https://github.com/velocitysquared/FreeImage.Standard</RepositoryUrl>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Description>
       FreeImage (http://freeimage.sourceforge.net/) wrapper targetting .NET Standard 2.0.


### PR DESCRIPTION
Prefixed the Nuget Package with a V2 to ensure we don't have version number conflicts.
Updated the readme.